### PR TITLE
add support for configuring the HTTP proxy

### DIFF
--- a/common/lib/azure/storage/common/client.rb
+++ b/common/lib/azure/storage/common/client.rb
@@ -40,6 +40,7 @@ module Azure::Storage::Common
     #
     # Accepted key/value pairs in options parameter are:
     #
+    # * +:proxy_uri+                      - String. The URI of the HTTP proxy to use.
     # * +:use_development_storage+        - TrueClass|FalseClass. Whether to use storage emulator.
     # * +:development_storage_proxy_uri+  - String. Used with +:use_development_storage+ if emulator is hosted other than localhost.
     # * +:storage_connection_string+      - String. The storage connection string.
@@ -91,6 +92,7 @@ module Azure::Storage::Common
       #
       # Accepted key/value pairs in options parameter are:
       #
+      # * +:proxy_uri+                      - String. The URI of the HTTP proxy to use.
       # * +:use_development_storage+        - TrueClass|FalseClass. Whether to use storage emulator.
       # * +:development_storage_proxy_uri+  - String. Used with +:use_development_storage+ if emulator is hosted other than localhost.
       # * +:storage_account_name+           - String. The name of the storage account.

--- a/common/lib/azure/storage/common/client_options.rb
+++ b/common/lib/azure/storage/common/client_options.rb
@@ -30,7 +30,7 @@ require "azure/storage/common/core/auth/anonymous_signer"
 
 module Azure::Storage::Common
   module ClientOptions
-    attr_accessor :ca_file, :ssl_version, :ssl_min_version, :ssl_max_version
+    attr_accessor :ca_file, :ssl_version, :ssl_min_version, :ssl_max_version, :proxy_uri
 
     # Public: Reset options for [Azure::Storage::Common::Client]
     #
@@ -42,6 +42,7 @@ module Azure::Storage::Common
     #
     # Accepted key/value pairs in options parameter are:
     #
+    # * +:proxy_uri+                      - String. The URI of the HTTP proxy to use.
     # * +:use_development_storage+        - TrueClass|FalseClass. Whether to use storage emulator.
     # * +:development_storage_proxy_uri+  - String. Used with +:use_development_storage+ if emulator is hosted other than localhost.
     # * +:storage_connection_string+      - String. The storage connection string.
@@ -91,6 +92,8 @@ module Azure::Storage::Common
       @ssl_version = options.delete(:ssl_version)
       @ssl_min_version = options.delete(:ssl_min_version)
       @ssl_max_version = options.delete(:ssl_max_version)
+      @proxy_uri = options.delete(:proxy_uri)
+      
       @options = filter(options)
       self.send(:reset_config!, @options) if self.respond_to?(:reset_config!)
       self
@@ -307,6 +310,7 @@ module Azure::Storage::Common
         raise InvalidOptionsError, "At least one of #{at_least_one} is required" unless at_least_one.length == 0 || at_least_one.any? { |k| opts.key? k }
 
         @@option_validators ||= {
+          proxy_uri: is_url,
           use_development_storage: is_true,
           development_storage_proxy_uri: is_url,
           storage_account_name: lambda { |i| i.is_a?(String) },

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -65,7 +65,9 @@ module Azure::Storage::Common::Core
           ssl_options[:ca_file] = self.ca_file if self.ca_file
           ssl_options[:verify] = true
         end
-        proxy_options = if ENV["HTTP_PROXY"]
+        proxy_options = if self.proxy_uri
+                          URI::parse(self.proxy_uri)
+                        elsif ENV["HTTP_PROXY"]
                           URI::parse(ENV["HTTP_PROXY"])
                         elsif ENV["HTTPS_PROXY"]
                           URI::parse(ENV["HTTPS_PROXY"])

--- a/test/unit/config/client_test.rb
+++ b/test/unit/config/client_test.rb
@@ -33,6 +33,7 @@ describe Azure::Storage::Common::Client do
     @access_key = "YWNjZXNzLWtleQ=="
     @mock_blob_host_with_protocol = "http://www.blob.net"
     @mock_sas = "?sv=2014-02-14&sr=b&sig=T42yqGMPksTcuMENIOyM%2F25P%2BMO1z2w1NdFwKucbGaA%3D&se=2015-07-10T03%3A26%3A27Z&sp=rwd"
+    @proxy_uri = "https://localhost:8080"
 
     @account_key_options = {
       storage_account_name: @account_name,
@@ -190,6 +191,13 @@ describe Azure::Storage::Common::Client do
       _(c.storage_account_name).must_equal(@account_name)
       _(lambda { c.options.storage_access_key }).must_raise(NoMethodError)
       _(c.storage_sas_token).must_equal(@mock_sas)
+    end
+
+    it "should set proxy if given" do
+      opts = { storage_account_name: @account_name, storage_sas_token: @mock_sas, proxy_uri: @proxy_uri }
+      c = Azure::Storage::Common::Client.create(opts)
+      _(c).wont_be_nil
+      _(c.proxy_uri).must_equal(@proxy_uri)
     end
 
     it "should fail if both sas_token and key" do

--- a/test/unit/core/http_client_test.rb
+++ b/test/unit/core/http_client_test.rb
@@ -7,6 +7,14 @@ describe Azure::Storage::Common::Core::HttpClient do
     URI("https://management.core.windows.net")
   end
 
+  let :storage_account_name do
+    "mockaccount"
+  end
+
+  let :storage_access_key do
+    "YWNjZXNzLWtleQ=="
+  end
+
   describe "#agents" do
     describe "reusing a connection when connecting to the same host" do
       let(:client) { Azure::Storage::Common::Client::create }
@@ -32,7 +40,26 @@ describe Azure::Storage::Common::Core::HttpClient do
       end
     end
 
-    describe "when using a http proxy" do
+    describe "when using a http proxy set via config" do
+      let(:http_proxy_uri) { URI("http://example.com:80") }
+ 
+      it "should set the proxy configuration information on the http connection" do
+        client = Azure::Storage::Common::Client::create(proxy_uri: http_proxy_uri.to_s, storage_account_name: storage_account_name, storage_access_key: storage_access_key)
+
+        _(client.agents(uri).proxy.uri).must_equal http_proxy_uri
+      end
+    end
+
+    describe "when using a https proxy set via config" do
+      let(:https_proxy_uri) { URI("https://example.com:443") }
+
+      it "should set the proxy configuration information on the https connection" do
+        client = Azure::Storage::Common::Client::create(proxy_uri: https_proxy_uri.to_s, storage_account_name: storage_account_name, storage_access_key: storage_access_key)
+        _(client.agents(uri).proxy.uri).must_equal https_proxy_uri
+      end
+    end
+
+    describe "when using a http proxy set via env" do
       let(:http_proxy_uri) { URI("http://localhost:80") }
 
       before do
@@ -48,7 +75,7 @@ describe Azure::Storage::Common::Core::HttpClient do
       end
     end
 
-    describe "when using a https proxy" do
+    describe "when using a https proxy set via env" do
       let(:https_proxy_uri) { URI("https://localhost:443") }
 
       before do


### PR DESCRIPTION
### Description
This PR adds configuration support for use of an HTTP/S proxy, which we'll need for all communications with Azure.

### Security

* [ ] These changes carry a [high security risk](https://bit.ly/2P8XCHu) and have received an [AppSec review](https://bit.ly/2JJhaiO).

### Data

This branch changes interactions with the following data stores:

* [ ] Elasticsearch 
* [ ] MongoDB
* [ ] MySQL 
* [ ] Redis